### PR TITLE
fix: export "types" before "import"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "module": "./lib/esm/public_api.js",
   "exports": {
     ".": {
-      "import": "./lib/esm/public_api.js",
-      "types": "./lib/types/index.d.ts"
+      "types": "./lib/types/index.d.ts",
+      "import": "./lib/esm/public_api.js"
     }
   },
   "files": [


### PR DESCRIPTION
export `types` first as per https://nodejs.org/docs/latest-v22.x/api/packages.html#packages_community_conditions_definitions

The error that I'm getting with v1.0.12 is:

> `There are types at '/workspaces/…/node_modules/@dynamize/color-utilities/lib/types/public_api.d.ts', but this result could not be resolved when respecting package.json "exports". The '@dynamize/color-utilities' library may need to update its package.json or typings.`

I'm using pnpm v9.15.0 on a Node.js v22 machine